### PR TITLE
vim: add vim spelling improvements

### DIFF
--- a/vim/vimrc.symlink
+++ b/vim/vimrc.symlink
@@ -164,6 +164,9 @@ map <leader>sn ]s
 map <leader>sp [s
 map <leader>sa zg
 map <leader>s? z=
+map <leader>su zw
+
+hi SpellBad cterm=underline ctermfg=red
 
 " }}}
 
@@ -215,6 +218,8 @@ if !empty(glob('~/.vim/pack/default/start/gruvbox'))
 				\ || !empty(glob('~/.vim/plugged/vim-airline'))
 		let g:airline_theme='gruvbox'
 	endif
+
+	let g:gruvbox_guisp_as_guifg=1
 endif
 
 " }}}


### PR DESCRIPTION
for some reason I need to source the vimrc after vim has already loaded
	the vimrc to get the bad spell highlighting...

Issue: #22
closes #22 