### PR TITLE
don't output error message when python3 not found

### DIFF
--- a/bash/env.bash
+++ b/bash/env.bash
@@ -75,9 +75,11 @@ is-executable thefuck && eval "$(thefuck --alias)"
 
 # python venv
 export WORKON_HOME=~/.virtualenvs
-VIRTUALENVWRAPPER_PYTHON=$(which python3)
-export VIRTUALENVWRAPPER_PYTHON
-[ -f /usr/local/bin/virtualenvwrapper.sh ] && source /usr/local/bin/virtualenvwrapper.sh
+VIRTUALENVWRAPPER_PYTHON=$(which python3 2> /dev/null)
+if [[ $? == 0 ]]; then
+	export VIRTUALENVWRAPPER_PYTHON
+	[ -f /usr/local/bin/virtualenvwrapper.sh ] && source /usr/local/bin/virtualenvwrapper.sh
+fi
 
 # opt out of dotnet CLI telemetry
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/bash/env.bash
+++ b/bash/env.bash
@@ -75,8 +75,7 @@ is-executable thefuck && eval "$(thefuck --alias)"
 
 # python venv
 export WORKON_HOME=~/.virtualenvs
-VIRTUALENVWRAPPER_PYTHON=$(which python3 2> /dev/null)
-if [[ $? == 0 ]]; then
+if VIRTUALENVWRAPPER_PYTHON=$(which python3 2> /dev/null); then
 	export VIRTUALENVWRAPPER_PYTHON
 	[ -f /usr/local/bin/virtualenvwrapper.sh ] && source /usr/local/bin/virtualenvwrapper.sh
 fi


### PR DESCRIPTION
- also only proceed with the rest of the virtualenv config if python3
	was found

closes #34